### PR TITLE
Distinguish between `Subprocess` and `Shell` transformations.

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -3,8 +3,12 @@ extensions = [
     "sphinx.ext.doctest",
     "sphinx.ext.napoleon",
     "sphinx.ext.autodoc",
+    "sphinx.ext.intersphinx",
     "sphinx_rtd_theme",
 ]
 project = "beaver"
 napoleon_custom_sections = [("Returns", "params_style")]
 html_theme = "sphinx_rtd_theme"
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+}

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -30,7 +30,7 @@ def test_raise_if_multiple_parents():
 
 
 def test_shell_command(tempdir):
-    output, = bt.Shell("directory/output.txt", None, "echo hello > $@".split())
+    output, = bt.Shell("directory/output.txt", None, "echo hello > $@")
     asyncio.run(output())
     assert output.digest.hex() == "5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03"
 
@@ -113,9 +113,10 @@ def test_caching(tempdir):
         assert len(calls) == 1
 
 
-def test_raise_if_invalid_shell_cmd():
-    with pytest.raises(TypeError):
-        bt.Shell(None, None, 1)
+@pytest.mark.parametrize('shell', [False, True])
+def test_raise_if_invalid_subprocess_cmd(shell):
+    with pytest.raises(ValueError):
+        bt.Subprocess(None, None, 1, shell=shell)
 
 
 def test_raise_if_shell_error():
@@ -195,3 +196,9 @@ def test_cancel_long_running_transformation():
         with pytest.raises(asyncio.CancelledError):
             await task
     asyncio.run(target())
+
+
+def test_subprocess(tempdir):
+    dummy, = bt.Subprocess("dummy.txt", None, ["sh", "-c", "echo hello > dummy.txt"])
+    asyncio.run(ba.gather_artifacts(dummy))
+    assert dummy.digest.hex() == "5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03"


### PR DESCRIPTION
This PR side-steps and fixes #24 by introducing two separate transformations:

- `Shell` executes a string in the shell verbatim, e.g. `echo hello`.
- `Subprocess` executes a subprocess given a sequence of command parts, e.g. `["echo", "hello"]`.

Decided to forget about "smart" escaping because there are too many different scenarios.